### PR TITLE
chore: upgrade to pnpm 11, migrate build allowlist to pnpm-workspace.yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,11 +28,5 @@
     "@types/node": "^22.12.0",
     "tsx": "^4.21.0"
   },
-  "packageManager": "pnpm@10.18.2",
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild",
-      "sharp"
-    ]
-  }
+  "packageManager": "pnpm@11.3.0"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  esbuild: true
+  sharp: true


### PR DESCRIPTION
## What
- Bump `packageManager` pin: `pnpm@10.18.2` → `pnpm@11.3.0`
- Migrate the build-script allowlist from package.json's `pnpm.onlyBuiltDependencies` to `allowBuilds` in a new `pnpm-workspace.yaml`

## Why
pnpm 11 **removed** `onlyBuiltDependencies` and now gates package build scripts behind `allowBuilds`. Without this migration, esbuild and sharp would be blocked from running their native-binary install scripts on a fresh install (CI / Docker), breaking the build.

## Verification (local + Docker)
- ✅ Clean `pnpm install` runs esbuild + sharp build scripts (no `ERR_PNPM_IGNORED_BUILDS`)
- ✅ `pnpm build` succeeds on Node 24.16.0 + pnpm 11.3.0
- ✅ Production Docker build (`--frozen-lockfile` in `node:24-slim`, corepack pulls pnpm 11.3.0) — runtime image builds
- ⏳ CI (`ci.yaml`) + E2E (`e2e.yaml`) run on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)